### PR TITLE
Add scala to the filetype

### DIFF
--- a/ftdetect/sbt.vim
+++ b/ftdetect/sbt.vim
@@ -3,4 +3,4 @@
 " Maintainer:   Derek Wyatt <derek@{myfirstname}{mylastname}.org>
 " Last Change:  2012 Jan 19
 
-au BufRead,BufNewFile *.sbt set filetype=sbt
+au BufRead,BufNewFile *.sbt set filetype=sbt.scala


### PR DESCRIPTION
The companion to derekwyatt/vim-scala@e6e1237. This triggers other parts of vim-scala's ftplugin to load on sbt files that are useful, like default shiftwidth/softtabstop, etc. It will also mean that the filetype is set to `sbt.scala` no matter whether vim-sbt or vim-scala loads first.
